### PR TITLE
Added payment element check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Added payment element check in implementation of hook_webform_submission_insert.
+
 ## [1.0.0] - 2024-12-06
 
 ### Updated

--- a/src/Helper/PaymentHelper.php
+++ b/src/Helper/PaymentHelper.php
@@ -62,11 +62,15 @@ class PaymentHelper {
    *   Return
    */
   public function webformSubmissionPresave(WebFormSubmissionInterface $submission): void {
+
+    // Only modify submission if payment element exists.
     ['paymentElement' => $paymentElement, 'paymentElementMachineName' => $paymentElementMachineName] = $this->getWebformElementNames($submission);
-    $submissionData = $submission->getData();
+
     if (!isset($paymentElement) && !isset($paymentElementMachineName)) {
       return;
     }
+
+    $submissionData = $submission->getData();
 
     /*
      * The paymentReferenceField is not a part of the form submission,
@@ -182,6 +186,14 @@ class PaymentHelper {
    *   Throws exception.
    */
   public function webformSubmissionInsert(WebFormSubmissionInterface $submission): void {
+
+    // Only modify submission if payment element exists.
+    ['paymentElement' => $paymentElement, 'paymentElementMachineName' => $paymentElementMachineName] = $this->getWebformElementNames($submission);
+
+    if (!isset($paymentElement) && !isset($paymentElementMachineName)) {
+      return;
+    }
+
     $logger_context = [
       'handler_id' => 'os2forms_payment',
       'channel' => 'webform_submission',


### PR DESCRIPTION
#### Link to ticket

[3090](https://leantime.itkdev.dk/?tab=ticketdetails#/tickets/showTicket/3090)

#### Description

Any submission is currently modified by the `hook_webform_submission_insert` implementation `webformSubmissionInsert`. Subsequently, a (failing) payment job is created.

Added check for payment element avoids modifying submissions when no payment element in present. It is basically copied from the other hook implemented -it was probably just missed in the second hook.
