### PR TITLE
Feature: User definable terms urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- User definable terms and condition urls
+
 ## [1.0.1] - 2024-12-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ $settings['os2forms_payment']['checkout_key'] = '';
 // SECRET_KEY, both test and production, can be retrieved from Nets admin panel
 $settings['os2forms_payment']['secret_key'] = '';
 
-// Static page containing terms and conditions, e.g. /node/87
+// Page containing terms and conditions URL, including protocol.
 $settings['os2forms_payment']['terms_url'] = '';
+
+// Page containing merchant terms URL, including protocol.
+$settings['os2forms_payment']['merchant_terms_url'] = '';
 
 // Boolean describing whether the module is operated in test mode
 $settings['os2forms_payment']['test_mode'] = TRUE;

--- a/src/Controller/NetsEasyController.php
+++ b/src/Controller/NetsEasyController.php
@@ -56,6 +56,8 @@ class NetsEasyController extends ControllerBase {
     $callbackUrl = $request->get('callbackUrl');
     $paymentPosting = $request->get('paymentPosting');
     $paymentMethods = $request->get('paymentMethods');
+    $termsAndConditionsUrl = $request->get('termsAndConditionsUrl');
+    $merchantTermsUrl = $request->get('merchantTermsUrl');
 
     $paymentMethodsConfiguration = array_map(
       static fn($name) => ['name' => $name, 'enabled' => TRUE],
@@ -71,8 +73,8 @@ class NetsEasyController extends ControllerBase {
       'checkout' => [
         'integrationType' => 'EmbeddedCheckout',
         'url' => $callbackUrl,
-        'termsUrl' => $this->paymentHelper->getTermsUrl(),
-        'merchantTermsUrl' => $this->paymentHelper->getTermsUrl(),
+        'termsUrl' => $termsAndConditionsUrl,
+        'merchantTermsUrl' => $merchantTermsUrl,
         'merchantHandlesConsumerData' => TRUE,
         'publicDevice' => TRUE,
         'shipping' => [

--- a/src/Helper/PaymentHelper.php
+++ b/src/Helper/PaymentHelper.php
@@ -329,6 +329,16 @@ class PaymentHelper {
   }
 
   /**
+   * Returns the url for the page displaying merchant terms and conditions.
+   *
+   * @return string
+   *   The merchant terms and conditions url.
+   */
+  public function getMerchantTermsUrl(): ?string {
+    return $this->getPaymentSettings()['merchant_terms_url'] ?? NULL;
+  }
+
+  /**
    * Returns whether the module is operated in test mode.
    *
    * @return bool

--- a/src/Plugin/WebformElement/NetsEasyPaymentElement.php
+++ b/src/Plugin/WebformElement/NetsEasyPaymentElement.php
@@ -51,6 +51,8 @@ class NetsEasyPaymentElement extends WebformElementBase {
       'checkout_language' => [],
       'amount_to_pay' => '',
       'checkout_page_description' => '',
+      'terms_and_conditions_url' => $this->paymentHelper->getTermsUrl(),
+      'merchant_terms_url' => $this->paymentHelper->getMerchantTermsUrl(),
       'payment_methods' => ['Card'],
       'payment_posting' => '',
     ] + parent::defineDefaultProperties();
@@ -93,6 +95,16 @@ class NetsEasyPaymentElement extends WebformElementBase {
       '#description' => $this
         ->t('This field supports simple html'),
     ];
+    $form['element']['terms_and_conditions_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Terms and conditions URL'),
+      '#description' => $this->t('The complete URL to the terms and conditions, including the protocol. Example: https://www.example.com/terms-and-conditions'),
+    ];
+    $form['element']['merchant_terms_url'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('The merchant terms URL'),
+      '#description' => $this->t('The complete URL to the merchant terms, including the protocol. Example: https://www.example.com/merchant-terms'),
+    ];
 
     $form['element']['payment_posting'] = [
       '#type' => 'textfield',
@@ -131,7 +143,8 @@ class NetsEasyPaymentElement extends WebformElementBase {
       ? 'os2forms_payment/nets_easy_test'
       : 'os2forms_payment/nets_easy_prod';
     $callbackUrl = Url::fromRoute('<current>')->setAbsolute()->toString(TRUE)->getGeneratedUrl();
-    $webformCurrentPage = $form['progress']['#current_page'];
+
+    $webformCurrentPage = $formState->get('current_page');
     // Check if we are on the preview page.
     if ($webformCurrentPage === "webform_preview") {
       $amountToPay = $this->paymentHelper->getAmountToPay($formState->getUserInput(), $this->getElementProperty($element, 'amount_to_pay'));
@@ -147,6 +160,9 @@ class NetsEasyPaymentElement extends WebformElementBase {
       $paymentMethods = array_values(array_filter($element['#payment_methods'] ?? []));
       $paymentPosting = $element['#payment_posting'] ?? 'undefined';
       $checkoutLanguage = $element['#checkout_language'] ?? 'da-DK';
+      $termsAndConditionsUrl = $element['#terms_and_conditions_url'] ?? '';
+      $merchantTermsUrl = $element['#merchant_terms_url'] ?? '';
+
 
       $form['os2forms_payment_checkout_container'] = [
         '#type' => 'container',
@@ -161,6 +177,8 @@ class NetsEasyPaymentElement extends WebformElementBase {
               'callbackUrl' => $callbackUrl,
               'paymentMethods' => $paymentMethods,
               'paymentPosting' => $paymentPosting,
+              'termsAndConditionsUrl' => $termsAndConditionsUrl,
+              'merchantTermsUrl' => $merchantTermsUrl,
             ])->toString(TRUE)->getGeneratedUrl(),
         ],
         '#limit_validation_errors' => [],

--- a/src/Plugin/WebformElement/NetsEasyPaymentElement.php
+++ b/src/Plugin/WebformElement/NetsEasyPaymentElement.php
@@ -163,7 +163,6 @@ class NetsEasyPaymentElement extends WebformElementBase {
       $termsAndConditionsUrl = $element['#terms_and_conditions_url'] ?? '';
       $merchantTermsUrl = $element['#merchant_terms_url'] ?? '';
 
-
       $form['os2forms_payment_checkout_container'] = [
         '#type' => 'container',
         '#attributes' => [

--- a/src/Plugin/WebformElement/NetsEasyPaymentElement.php
+++ b/src/Plugin/WebformElement/NetsEasyPaymentElement.php
@@ -99,11 +99,13 @@ class NetsEasyPaymentElement extends WebformElementBase {
       '#type' => 'textfield',
       '#title' => $this->t('Terms and conditions URL'),
       '#description' => $this->t('The complete URL to the terms and conditions, including the protocol. Example: https://www.example.com/terms-and-conditions'),
+      '#required' => TRUE,
     ];
     $form['element']['merchant_terms_url'] = [
       '#type' => 'textfield',
       '#title' => $this->t('The merchant terms URL'),
       '#description' => $this->t('The complete URL to the merchant terms, including the protocol. Example: https://www.example.com/merchant-terms'),
+      '#required' => TRUE,
     ];
 
     $form['element']['payment_posting'] = [
@@ -119,6 +121,7 @@ class NetsEasyPaymentElement extends WebformElementBase {
         'Card' => $this->t('Kortbetaling'),
         'MobilePay' => $this->t('MobilePay'),
       ],
+      '#required' => TRUE,
     ];
 
     return $form;


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

Added two fields to the element, defining the terms and conditions as well as the merchant terms urls. Defaults to 
$settings['os2forms_payment']['terms_url']
and
$settings['os2forms_payment']['merchant_terms_url']

in settings.local
